### PR TITLE
Use a temporal dir as home to allow libreoffice convert on servers

### DIFF
--- a/jam/report.py
+++ b/jam/report.py
@@ -170,7 +170,7 @@ class Report(object):
                 else:
                     s_office = "soffice"
                 convertion = Popen([s_office, '--headless', '--convert-to', self.ext.strip('.'),
-                    self.report_filename, '--outdir', self.dest_folder],
+                    self.report_filename, '--outdir', self.dest_folder],env={"HOME": '/tmp'},
                     stderr=STDOUT,stdout=PIPE)
                 out, err = convertion.communicate()
             except Exception as e:


### PR DESCRIPTION
When deploy the app on a debian system server. The PDF conversion does not work on reports unless you set up a HOME environment with writer permissions. This change use /tmp